### PR TITLE
itemsのCRUDの実装

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: backend
     build: ./backend/
     image: backend
-    command: bundle exec rails server -b 0.0.0.0
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b '0.0.0.0'"
     tty: true
     stdin_open: true
     volumes:

--- a/frontend/pages/todos/_todoId/items.vue
+++ b/frontend/pages/todos/_todoId/items.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <div>itemの一覧</div>
+    <div>itemを格納しているtodoのID: {{ todoId }}</div>
+    <div v-if="items.length === 0">itemなし</div>
+    <ul v-for="(item, index) in items" :key="`items-${index}`">
+      <li>{{ item }}</li>
+    </ul>
+    <nuxt-link :to="{ name: 'todos-todoid', params: { todoid: todoId } }">todoへ戻る</nuxt-link>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+
+export default {
+  data() {
+    return {
+      todoId: this.$route.params.todoId
+    }
+  },
+  async asyncData({ route, store }) {
+    await store.dispatch('fetchItems', route.params.todoId)
+  },
+  mounted() {},
+  computed: {
+    ...mapGetters(['items'])
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/pages/todos/_todoId/items/_itemId/edit.vue
+++ b/frontend/pages/todos/_todoId/items/_itemId/edit.vue
@@ -14,6 +14,7 @@
       <div v-if="!itemForm.done">未完了</div>
       <button type="submit">更新</button>
     </form>
+    <button type="button" @click="clickDeleteItem">削除</button>
     <nuxt-link :to="{ name: 'todos-todoId-items-itemid', params: { todoId: todoId, itemid: itemId } }">itemの詳細に戻る</nuxt-link>
   </div>
 </template>
@@ -52,7 +53,13 @@ export default {
         this.$router.push(`/todos/${this.todoId}/items/${this.itemId}`)
       }
     },
-    ...mapActions(['updateItem'])
+    async clickDeleteItem() {
+      if(confirm(`${this.item.name}を削除しますか？`)) {
+        await this.deleteItem({ todoId: this.todoId, itemId: this.itemId })
+        this.$router.push(`/todos/${this.todoId}/items`)
+      }
+    },
+    ...mapActions(['updateItem', 'deleteItem'])
   },
 }
 </script>

--- a/frontend/pages/todos/_todoId/items/_itemId/edit.vue
+++ b/frontend/pages/todos/_todoId/items/_itemId/edit.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <div>itemを編集</div>
+    <div>itemのID: {{ itemId }}</div>
+    <div>格納しているtodoのID: {{ todoId }}</div>
+    <form @submit.prevent="submitUpdateItem">
+      <input type="text" v-model="itemForm.name">
+      <select v-model="itemForm.done">
+        <option v-for="(option, index) in options" :key="`options-${index}`" v-bind:value="option.value">
+          {{ option.text }}
+        </option>
+      </select>
+      <div v-if="itemForm.done">完了</div>
+      <div v-if="!itemForm.done">未完了</div>
+      <button type="submit">更新</button>
+    </form>
+    <nuxt-link :to="{ name: 'todos-todoId-items-itemid', params: { todoId: todoId, itemid: itemId } }">itemの詳細に戻る</nuxt-link>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+
+export default {
+  data() {
+    return {
+      todoId: this.$route.params.todoId,
+      itemId: this.$route.params.itemId,
+      options: [
+        { text: '未完了', value: false },
+        { text: '完了', value: true },
+      ],
+    }
+  },
+  async asyncData({ route, store }) {
+    await store.dispatch('showItem', { todoId: route.params.todoId, itemId: route.params.itemId })
+
+    return {
+      itemForm: {
+        name: store.getters['item'].name,
+        done: store.getters['item'].done,
+      }
+    }
+  },
+  computed: {
+    ...mapGetters(['item'])
+  },
+  methods: {
+    async submitUpdateItem() {
+      if(this.itemForm.name) {
+        await this.updateItem({ todoId: this.todoId, itemId: this.itemId, name: this.itemForm.name, done: this.itemForm.done })
+        this.$router.push(`/todos/${this.todoId}/items/${this.itemId}`)
+      }
+    },
+    ...mapActions(['updateItem'])
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/pages/todos/_todoId/items/_itemid.vue
+++ b/frontend/pages/todos/_todoId/items/_itemid.vue
@@ -4,6 +4,8 @@
     <div>itemのID: {{ itemId }}</div>
     <div>格納しているtodoのID: {{ todoId }}</div>
     <div>{{ item }}</div>
+    <nuxt-link :to="{　name: 'todos-todoId-items-itemId-edit', params: { todoId: todoId, itemId: itemId }　}">itemを編集</nuxt-link>
+    <nuxt-link :to="{ name: 'todos-todoId-items', params: { todoid: todoId } }">itemの一覧に戻る</nuxt-link>
   </div>
 </template>
 

--- a/frontend/pages/todos/_todoId/items/_itemid.vue
+++ b/frontend/pages/todos/_todoId/items/_itemid.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <div>itemの詳細</div>
+    <div>itemのID: {{ itemId }}</div>
+    <div>格納しているtodoのID: {{ todoId }}</div>
+    <div>{{ item }}</div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  data() {
+    return {
+      todoId: this.$route.params.todoId,
+      itemId: this.$route.params.itemid,
+    }
+  },
+  async asyncData({ route, store }) {
+    await store.dispatch('showItem', { todoId: route.params.todoId, itemId: route.params.itemid })
+  },
+  computed: {
+    ...mapGetters(['item'])
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/pages/todos/_todoId/items/index.vue
+++ b/frontend/pages/todos/_todoId/items/index.vue
@@ -4,7 +4,7 @@
     <div>itemを格納しているtodoのID: {{ todoId }}</div>
     <div v-if="items.length === 0">itemなし</div>
     <ul v-for="(item, index) in items" :key="`items-${index}`">
-      <li>{{ item }}</li>
+      <li><nuxt-link :to="{ name: 'todos-todoId-items-itemid', params: { todoId: todoId, itemid: item.id } }">{{ item }}</nuxt-link></li>
     </ul>
     <nuxt-link :to="{ name: 'todos-todoid', params: { todoid: todoId } }">todoへ戻る</nuxt-link>
     <nuxt-link :to="{ name: 'todos-todoId-items-new', params: { todoid: todoId } }">itemを作成</nuxt-link>

--- a/frontend/pages/todos/_todoId/items/index.vue
+++ b/frontend/pages/todos/_todoId/items/index.vue
@@ -7,6 +7,7 @@
       <li>{{ item }}</li>
     </ul>
     <nuxt-link :to="{ name: 'todos-todoid', params: { todoid: todoId } }">todoへ戻る</nuxt-link>
+    <nuxt-link :to="{ name: 'todos-todoId-items-new', params: { todoid: todoId } }">itemを作成</nuxt-link>
   </div>
 </template>
 

--- a/frontend/pages/todos/_todoId/items/new.vue
+++ b/frontend/pages/todos/_todoId/items/new.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <div>itemを追加</div>
+    <div>格納元のtodoのID: {{ todoId }}</div>
+    <form @submit.prevent="submitCreateItem">
+      <input type="text" v-model="itemForm.name">
+      <button type="submit">追加</button>
+    </form>
+    <nuxt-link :to="{ name: 'todos-todoId-items', params: { todoid: todoId } }">itemの一覧に戻る</nuxt-link>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+
+export default {
+  data() {
+    return {
+      todoId: this.$route.params.todoId,
+      itemForm: { name: '', done: false }
+    }
+  },
+  methods: {
+    async submitCreateItem() {
+      if(this.itemForm.name) {
+        await this.createItems({ todoId: this.todoId, name: this.itemForm.name, done: this.itemForm.done })
+        this.itemForm.name = ''
+        this.$router.push(`/todos/${this.todoId}/items`)
+      }
+    },
+    ...mapActions(['createItems'])
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/pages/todos/_todoid.vue
+++ b/frontend/pages/todos/_todoid.vue
@@ -9,6 +9,7 @@
       <li>{{ item }}</li>
     </ul>
     <nuxt-link :to="{ name: 'todos-todoId-edit', params: { todoId: todoId } }">todoを編集</nuxt-link>
+    <nuxt-link :to="{ name: 'todos-todoId-items', params: { todoId: todoId } }">items一覧へ</nuxt-link>
     <nuxt-link to="/">トップに戻る</nuxt-link>
   </div>
 </template>

--- a/frontend/pages/todos/_todoid.vue
+++ b/frontend/pages/todos/_todoid.vue
@@ -10,6 +10,7 @@
     </ul>
     <nuxt-link :to="{ name: 'todos-todoId-edit', params: { todoId: todoId } }">todoを編集</nuxt-link>
     <nuxt-link :to="{ name: 'todos-todoId-items', params: { todoId: todoId } }">items一覧へ</nuxt-link>
+    <nuxt-link to="/todos">todos一覧へ</nuxt-link>
     <nuxt-link to="/">トップに戻る</nuxt-link>
   </div>
 </template>

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -2,6 +2,7 @@ export const state = () => ({
   todos: [],
   todo: {},
   items: [],
+  item: {},
   todoItems: [],
 })
 
@@ -9,6 +10,7 @@ export const getters = {
   todos: state => state.todos,
   todo: state => state.todo,
   items: state => state.items,
+  item: state => state.item,
   todoItems: state => state.todoItems,
 }
 
@@ -37,6 +39,9 @@ export const mutations = {
   },
   addItems(state, newItem) {
     state.items.push(newItem)
+  },
+  showItem(state, item) {
+    state.item = item
   },
   setTodoItems(state, todoItems) {
     state.todoItems = todoItems
@@ -71,6 +76,10 @@ export const actions = {
   async createItems({ commit }, { todoId, name, done }) {
     const newItem = await this.$axios.$post(`/api/todos/${todoId}/items`, { name: name, done: done })
     commit('addItems', newItem)
+  },
+  async showItem({ commit }, { todoId, itemId }) {
+    const item = await this.$axios.$get(`/api/todos/${todoId}/items/${itemId}`)
+    commit('showItem', item)
   },
   async fetchTodoItems({ commit }, ids) {
     let todoItems = []

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -35,6 +35,9 @@ export const mutations = {
   setItems(state, items) {
     state.items = items
   },
+  addItems(state, newItem) {
+    state.items.push(newItem)
+  },
   setTodoItems(state, todoItems) {
     state.todoItems = todoItems
   },
@@ -61,9 +64,13 @@ export const actions = {
     const deleteTodoResponse = await this.$axios.$delete(`/api/todos/${todoId}`)
     commit('deleteTodo', deleteTodoResponse)
   },
-  async fetchItems({ commit }, id) {
-    const items = await this.$axios.$get(`/api/todos/${id}/items`)
+  async fetchItems({ commit }, todoId) {
+    const items = await this.$axios.$get(`/api/todos/${todoId}/items`)
     commit('setItems', items)
+  },
+  async createItems({ commit }, { todoId, name, done }) {
+    const newItem = await this.$axios.$post(`/api/todos/${todoId}/items`, { name: name, done: done })
+    commit('addItems', newItem)
   },
   async fetchTodoItems({ commit }, ids) {
     let todoItems = []

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -50,6 +50,9 @@ export const mutations = {
       item.done = updateItem.done
     }
   },
+  deleteItem(state, deleteItemResponse) {
+    state.items = deleteItemResponse
+  },
   setTodoItems(state, todoItems) {
     state.todoItems = todoItems
   },
@@ -91,6 +94,10 @@ export const actions = {
   async updateItem({ commit }, { todoId, itemId, name, done }) {
     const updateItem = await this.$axios.$put(`/api/todos/${todoId}/items/${itemId}`, { name: name, done: done })
     commit('updateItem', updateItem)
+  },
+  async deleteItem({ commit }, { todoId, itemId }) {
+    const deleteItemResponse = this.$axios.$delete(`/api/todos/${todoId}/items/${itemId}`)
+    commit('deleteItem', deleteItemResponse)
   },
   async fetchTodoItems({ commit }, ids) {
     let todoItems = []

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -43,6 +43,13 @@ export const mutations = {
   showItem(state, item) {
     state.item = item
   },
+  updateItem(state, updateItem) {
+    const item = state.items.find(item => item.id === updateItem.id)
+    if (item) {
+      item.name = updateItem.name
+      item.done = updateItem.done
+    }
+  },
   setTodoItems(state, todoItems) {
     state.todoItems = todoItems
   },
@@ -80,6 +87,10 @@ export const actions = {
   async showItem({ commit }, { todoId, itemId }) {
     const item = await this.$axios.$get(`/api/todos/${todoId}/items/${itemId}`)
     commit('showItem', item)
+  },
+  async updateItem({ commit }, { todoId, itemId, name, done }) {
+    const updateItem = await this.$axios.$put(`/api/todos/${todoId}/items/${itemId}`, { name: name, done: done })
+    commit('updateItem', updateItem)
   },
   async fetchTodoItems({ commit }, ids) {
     let todoItems = []

--- a/frontend/store/index.spec.js
+++ b/frontend/store/index.spec.js
@@ -24,7 +24,7 @@ const testAction = (context = {}, payload = {}) => {
 describe('store/index.js', () => {
   let store
   let todo1, todo2, new_todo, update_todo, delete_todo
-  let item1, item2, item3, item4, todo_to_items, new_item, update_item
+  let item1, item2, item3, item4, todo_to_items, new_item, update_item, delete_item
   beforeEach(() => {
     store = new Vuex.Store(_.cloneDeep(index))
     todo1 = { id: 1, title: 'title_1', created_by: '1', created_at: "", updated_at: "" }
@@ -39,6 +39,7 @@ describe('store/index.js', () => {
     delete_todo = { id: 3, title: 'title_delete', created_by: 'delete', created_at: "", updated_at: "" }
     new_item = { id: 5, name: "item_5", done: true, todo_id: 1, created_at: "", updated_at: "" }
     update_item = { id: 1, name: "item_1_change", done: false, todo_id: 1, created_at: "", updated_at: "" }
+    delete_item = { id: 5, name: "item_5_delete", done: true, todo_id: 1, created_at: "", updated_at: "" }
   })
 
   describe('getters', () => {
@@ -281,13 +282,18 @@ describe('store/index.js', () => {
   describe('DELETEのテスト', () => {
     let commit
     let todos
+    let items
     beforeEach(() => {
       commit = store.commit
       todos = [todo1, todo2, delete_todo]
-      let index = todos.indexOf(delete_todo)
-      todos.splice(index, 1)
+      let todo_index = todos.indexOf(delete_todo)
+      todos.splice(todo_index, 1)
+      items = [item1, item2, item3, item4, delete_item]
+      let item_index = items.indexOf(delete_item)
+      todos.splice(item_index, 1)
       store.replaceState({
         todos: todos,
+        items: items,
       })
     })
 
@@ -303,6 +309,23 @@ describe('store/index.js', () => {
         }
         await testAction({ commit }, delete_todo.id)
         expect(store.getters['todos']).not.toContainEqual(delete_todo)
+        done()
+      })
+    })
+
+    describe('deleteItem', () => {
+      test('itemを削除する', async done => {
+        action = 'deleteItem'
+        mockAxiosGetResult = {
+          "id": delete_item.id,
+          "name": delete_item.name,
+          "done": delete_item.done,
+          "todo_id": delete_item.todo_id,
+          "created_at": delete_item.created_at,
+          "updated_at": delete_item.updated_at
+        }
+        await testAction({ commit }, { todoId: todo1.id, itemId: delete_item.id })
+        expect(store.getters['items']).not.toContainEqual(delete_item)
         done()
       })
     })

--- a/frontend/store/index.spec.js
+++ b/frontend/store/index.spec.js
@@ -24,7 +24,7 @@ const testAction = (context = {}, payload = {}) => {
 describe('store/index.js', () => {
   let store
   let todo1, todo2, new_todo, update_todo, delete_todo
-  let item1, item2, item3, item4, todo_to_items
+  let item1, item2, item3, item4, todo_to_items, new_item
   beforeEach(() => {
     store = new Vuex.Store(_.cloneDeep(index))
     todo1 = { id: 1, title: 'title_1', created_by: '1', created_at: "", updated_at: "" }
@@ -37,6 +37,7 @@ describe('store/index.js', () => {
     new_todo = { id: 3, title: 'title_3', created_by: '3', created_at: "", updated_at: "" }
     update_todo = { id: 1, title: 'title_1_change', created_by: '1_change', created_at: "", updated_at: "" }
     delete_todo = { id: 3, title: 'title_delete', created_by: 'delete', created_at: "", updated_at: "" }
+    new_item = { id: 5, name: "item_5", done: true, todo_id: 1, created_at: "", updated_at: "" }
   })
 
   describe('getters', () => {
@@ -80,12 +81,14 @@ describe('store/index.js', () => {
     let todo
     let todoIds
     let items
+    let item
     let todoItems
     beforeEach(() => {
       commit = store.commit
       todos = [todo1, todo2]
       todo = todo1
       items = [item1, item2, item3, item4]
+      item = item1
       todo_to_items.items = items
       todoIds = [todo_to_items.id]
       todoItems = [todo_to_items]
@@ -93,6 +96,7 @@ describe('store/index.js', () => {
         todos: todos,
         todo: todo,
         items: items,
+        item: item,
         todoItems: todoItems,
       })
     })
@@ -141,6 +145,23 @@ describe('store/index.js', () => {
       })
     })
 
+    describe('showItem', () => {
+      test('itemをひとつ取得する', async done => {
+        action = 'showItem'
+        mockAxiosGetResult = {
+          "id": item1.id,
+          "name": item1.name,
+          "done": item1.done,
+          "todo_id": item1.todo_id,
+          "created_at": item1.created_at,
+          "updated_at": item1.updated_at
+        }
+        await testAction({ commit }, { todoId: todo1.id, itemId: item1.id })
+        expect(store.getters['item']).toEqual(item)
+        done()
+      })
+    })
+
     describe('fetchTodoItems', () => {
       test('todoItemsを取得する', async done => {
         action = 'fetchTodoItems'
@@ -155,11 +176,14 @@ describe('store/index.js', () => {
   describe('POSTのテスト', () => {
     let commit
     let todos
+    let items
     beforeEach(() => {
       commit = store.commit
       todos = [todo1, todo2, new_todo]
+      items = [item1, item2, item3, item4, new_item]
       store.replaceState({
         todos: todos,
+        items: items,
       })
     })
 
@@ -175,6 +199,23 @@ describe('store/index.js', () => {
         }
         await testAction({ commit }, { title: new_todo.title, created_by: new_todo.created_by })
         expect(store.getters['todos']).toContainEqual(new_todo)
+        done()
+      })
+    })
+
+    describe('createItems', () => {
+      test('新規itemを作成する', async done => {
+        action = 'createItems'
+        mockAxiosGetResult = {
+          "id": new_item.id,
+          "name": new_item.name,
+          "done": new_item.done,
+          "todo_id": new_item.todo_id,
+          "created_at": new_item.created_at,
+          "updated_at": new_item.updated_at
+        }
+        await testAction({ commit }, { todoId: todo1.id, name: new_item.name, done: new_item.done })
+        expect(store.getters['items']).toContainEqual(new_item)
         done()
       })
     })

--- a/frontend/store/index.spec.js
+++ b/frontend/store/index.spec.js
@@ -24,7 +24,7 @@ const testAction = (context = {}, payload = {}) => {
 describe('store/index.js', () => {
   let store
   let todo1, todo2, new_todo, update_todo, delete_todo
-  let item1, item2, item3, item4, todo_to_items, new_item
+  let item1, item2, item3, item4, todo_to_items, new_item, update_item
   beforeEach(() => {
     store = new Vuex.Store(_.cloneDeep(index))
     todo1 = { id: 1, title: 'title_1', created_by: '1', created_at: "", updated_at: "" }
@@ -38,6 +38,7 @@ describe('store/index.js', () => {
     update_todo = { id: 1, title: 'title_1_change', created_by: '1_change', created_at: "", updated_at: "" }
     delete_todo = { id: 3, title: 'title_delete', created_by: 'delete', created_at: "", updated_at: "" }
     new_item = { id: 5, name: "item_5", done: true, todo_id: 1, created_at: "", updated_at: "" }
+    update_item = { id: 1, name: "item_1_change", done: false, todo_id: 1, created_at: "", updated_at: "" }
   })
 
   describe('getters', () => {
@@ -224,13 +225,18 @@ describe('store/index.js', () => {
   describe('PUTのテスト', () => {
     let commit
     let todos
+    let items
     beforeEach(() => {
       commit = store.commit
       todos = [todo1, todo2]
       todos[0].title = update_todo.title
       todos[0].created_by = update_todo.created_by
+      items = [item1, item2, item3, item4]
+      items[0].name = update_item.name
+      items[0].done = update_item.done
       store.replaceState({
         todos: todos,
+        items: items,
       })
     })
 
@@ -248,6 +254,25 @@ describe('store/index.js', () => {
         let todo = store.getters['todos'].find(todo => todo.id === update_todo.id)
         expect(todo.title).toEqual(update_todo.title)
         expect(todo.created_by).toEqual(update_todo.created_by)
+        done()
+      })
+    })
+
+    describe('updateItem', () => {
+      test('itemを更新する', async done => {
+        action = 'updateItem'
+        mockAxiosGetResult = {
+          "id": item1.id,
+          "name": update_item.name,
+          "done": update_item.done,
+          "todo_id": item1.todo_id,
+          "created_at": item1.created_at,
+          "updated_at": item1.updated_at
+        }
+        await testAction({ commit }, { todoId: todo1.id, itemId: item1.id, name: update_item.name, done: update_item.done })
+        let item = store.getters['items'].find(item => item.id === update_item.id)
+        expect(item.name).toEqual(update_item.name)
+        expect(item.done).toEqual(update_item.done)
         done()
       })
     })


### PR DESCRIPTION
- `items`の取得
→ `fetchItems`をもとに一覧表示させる。

- `items`の追加
→ `items`を追加する`createItems`アクションを実行させる。
→ `name`を記述、`done`については`false`をデフォルトに追加する。
→ バリテーションとフラッシュメッセージを追加したい。

- `item`の詳細を追加
→ `item`単体を取得する`showItem`アクションを実行させる。

- `item`の更新
→ `item`単体を更新する`updateItem`アクションを実行。
→ バリテーションとフラッシュメッセージを追加したい。

- `item`の削除
→ `item`単体を削除する`deleteItem`アクションを実行。
→ フラッシュメッセージを追加したい。